### PR TITLE
Jblakeman solution

### DIFF
--- a/pixart.js
+++ b/pixart.js
@@ -12,3 +12,12 @@ colorField.addEventListener("keypress", function(event) {
     if (event.keyCode === 13) setBrushBoxColor(event);
 });
 
+function appendBody(tagName, className) {
+    newElement = document.createElement(tagName);
+    if (className) newElement.className = className;
+    document.body.appendChild(newElement);
+}
+
+for (var i = 0; i < 20; i++) {
+    appendBody("div", "square");
+}

--- a/pixart.js
+++ b/pixart.js
@@ -1,6 +1,5 @@
 
 function setBrushBoxColor(event) {
-    var brush = document.getElementsByClassName("brush")[0];
     brush.style.backgroundColor = colorField.value;
     event.preventDefault();
 }
@@ -11,12 +10,15 @@ function createNewElement(tagName, className) {
     return newElement;
 }
 
-function setSquareColor(event, color) {
-    event.target.style.backgroundColor = color;
+function setSquareColor(event) {
+    var brushStyle = window.getComputedStyle(brush);
+    var brushColor = brushStyle.getPropertyValue("background-color");
+    event.target.style.backgroundColor = brushColor;
 }
 
 var setColorButton = document.getElementById("set-color");
 var colorField = document.getElementById("color-field");
+var brush = document.getElementsByClassName("brush")[0];
 
 setColorButton.addEventListener("click", setBrushBoxColor);
 colorField.addEventListener("keypress", function(event) {
@@ -28,7 +30,7 @@ var numSquares = 20, newSquare, i;
 for (i = 0; i < numSquares; i++) {
     newSquare = createNewElement("div", "square");
     newSquare.addEventListener("click", function(event) {
-        setSquareColor(event, "green");
+        setSquareColor(event);
     });
     document.body.appendChild(newSquare);
 }

--- a/pixart.js
+++ b/pixart.js
@@ -8,4 +8,7 @@ function setBrushBoxColor(event) {
 }
 
 setColor.addEventListener("click", setBrushBoxColor);
+colorField.addEventListener("keypress", function(event) {
+    if (event.keyCode === 13) setBrushBoxColor(event);
+});
 

--- a/pixart.js
+++ b/pixart.js
@@ -26,10 +26,10 @@ colorField.addEventListener("keypress", function(event) {
 });
 
 
-var numSquares = 20, newSquare, i;
+var numSquares = 8000, newSquare, i;
 for (i = 0; i < numSquares; i++) {
     newSquare = createNewElement("div", "square");
-    newSquare.addEventListener("click", function(event) {
+    newSquare.addEventListener("mouseover", function(event) {
         setSquareColor(event);
     });
     document.body.appendChild(newSquare);

--- a/pixart.js
+++ b/pixart.js
@@ -1,1 +1,11 @@
+var setColor = document.getElementById("set-color");
+var colorField = document.getElementById("color-field");
+
+function setBrushBoxColor(event) {
+    var brush = document.getElementsByClassName("brush")[0];
+    brush.style.backgroundColor = colorField.value;
+    event.preventDefault();
+}
+
+setColor.addEventListener("click", setBrushBoxColor);
 

--- a/pixart.js
+++ b/pixart.js
@@ -1,5 +1,3 @@
-var setColor = document.getElementById("set-color");
-var colorField = document.getElementById("color-field");
 
 function setBrushBoxColor(event) {
     var brush = document.getElementsByClassName("brush")[0];
@@ -7,17 +5,30 @@ function setBrushBoxColor(event) {
     event.preventDefault();
 }
 
-setColor.addEventListener("click", setBrushBoxColor);
+function createNewElement(tagName, className) {
+    newElement = document.createElement(tagName);
+    if (className) newElement.className = className;
+    return newElement;
+}
+
+function setSquareColor(event, color) {
+    event.target.style.backgroundColor = color;
+}
+
+var setColorButton = document.getElementById("set-color");
+var colorField = document.getElementById("color-field");
+
+setColorButton.addEventListener("click", setBrushBoxColor);
 colorField.addEventListener("keypress", function(event) {
     if (event.keyCode === 13) setBrushBoxColor(event);
 });
 
-function appendBody(tagName, className) {
-    newElement = document.createElement(tagName);
-    if (className) newElement.className = className;
-    document.body.appendChild(newElement);
-}
 
-for (var i = 0; i < 20; i++) {
-    appendBody("div", "square");
+var numSquares = 20, newSquare, i;
+for (i = 0; i < numSquares; i++) {
+    newSquare = createNewElement("div", "square");
+    newSquare.addEventListener("click", function(event) {
+        setSquareColor(event, "green");
+    });
+    document.body.appendChild(newSquare);
 }


### PR DESCRIPTION
Felt pretty comfortable with this exercise.

Some moderate googling was required for stuff that I couldn't find in the lesson repositories (don't recall if they'd been briefly mentioned in class or not):

e.g. `event.target` needing to be used in callback functions; how to access the current property value of an element's CSS style using something like: `window.getComputedStyle(element).getPropertyValue(property)`.

All requirements were met, although I didn't have time for the bonus.  I think I improved on some of the functionality of commit 5, as instructions don't specify that the `square` colors should only change to color of the `color-field` value when enter was pressed or change color button clicked.  Also, I made it so the initial default background color of the brush box (#1B4370) was immediately used in the square's mousover event listener before a new color-field value had ever been entered.
